### PR TITLE
Byttet ut 'management.endpoint.prometheus.enabled' som er deprikert m…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,7 @@
 spring.main.banner-mode=off
 server.shutdown=graceful
 
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
+management.endpoint.prometheus.access=read_only
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.group.liveness.include=livenessState
 management.endpoints.web.base-path=/internal

--- a/src/test/kotlin/no/nav/amt_altinn_acl/ActuatorTest.kt
+++ b/src/test/kotlin/no/nav/amt_altinn_acl/ActuatorTest.kt
@@ -1,0 +1,61 @@
+package no.nav.amt_altinn_acl
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import no.nav.amt_altinn_acl.test_util.IntegrationTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.server.LocalManagementPort
+import org.springframework.http.HttpStatus
+import org.springframework.web.util.UriComponentsBuilder
+
+class ActuatorTest(
+	@LocalManagementPort private val managementPort: Int,
+	private val restTemplate: TestRestTemplate,
+) : IntegrationTest() {
+
+	@ParameterizedTest(name = "{0} probe skal returnere OK og status = UP")
+	@ValueSource(strings = ["liveness", "readiness"])
+	fun probe_skal_returnere_OK_og_status_UP(probeName: String) {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/health/{probeName}")
+				.buildAndExpand(managementPort, probeName)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		assertSoftly(response) {
+			statusCode shouldBe HttpStatus.OK
+			body shouldBe "{\"status\":\"UP\"}"
+		}
+	}
+
+	@Test
+	fun `Prometheus-endepunktet skal returnere OK`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/prometheus")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		response.statusCode shouldBe HttpStatus.OK
+	}
+
+	@Test
+	fun `Metrics-endepunktet skal returnere NOT_FOUND`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/metrics")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		response.statusCode shouldBe HttpStatus.NOT_FOUND
+	}
+}

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,17 +1,5 @@
-spring.main.banner-mode=off
-server.shutdown=graceful
-
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
-management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.liveness.include=livenessState
-management.endpoints.web.base-path=/internal
-management.endpoints.web.exposure.include=prometheus,health
-management.prometheus.metrics.export.enabled=true
-
 no.nav.security.jwt.issuer.azuread.discovery-url=http://localhost:8082/azuread/.well-known/openid-configuration
 no.nav.security.jwt.issuer.azuread.accepted-audience=test-aud
-
 altinn.koordinator-service-code=${ALTINN_KOORDINATOR_SERVICE_CODE:#{null}}
 altinn.veileder-service-code=${ALTINN_VEILEDER_SERVICE_CODE:#{null}}
 altinn3.url=${ALTINN3_URL:#{null}}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,15 +1,3 @@
-spring.main.banner-mode=off
-server.shutdown=graceful
-
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
-management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.liveness.include=livenessState
-management.endpoints.web.base-path=/internal
-management.endpoints.web.exposure.include=prometheus,health
-management.prometheus.metrics.export.enabled=true
-
 elector.path: dont_look_for_leader
-
 app.env.unleashUrl=https://amt-unleash.nais.io/api/
 app.env.unleashApiToken=token


### PR DESCRIPTION
- Byttet ut `management.endpoint.prometheus.enabled` som er deprikert med `management.endpoint.prometheus.access`. [Spring-Boot-3.4-Configuration-Changelog](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Configuration-Changelog)
- Fjernet deprikert `management.endpoint.metrics.enabled=true` fordi denne ikke er med i `management.endpoints.web.exposure.include` og er dermed overflødig.
- Fjernet entries fra _application-local.properties_ og _application-test.properties_ hvor nøkkel/verdi var lik som i _application.properties_.
- Lagt til tester for actuator-endepunktene

Det anbefales å konfigurere `management.server.port` til annen port enn for øvrige endepunkter.
