### PR TITLE
Med okhttp:5 er body non-null

### DIFF
--- a/src/main/kotlin/no/nav/amt_altinn_acl/client/altinn/Altinn3ClientImpl.kt
+++ b/src/main/kotlin/no/nav/amt_altinn_acl/client/altinn/Altinn3ClientImpl.kt
@@ -41,13 +41,11 @@ class Altinn3ClientImpl(
 
 		client.newCall(request).execute().use { response ->
 			if (!response.isSuccessful) {
-				log.error("Klarte ikke hente organisasjoner ${response.code}, body=${response.body?.string()?.maskerFnr()}")
+				log.error("Klarte ikke hente organisasjoner ${response.code}, body=${response.body.string().maskerFnr()}")
 				throw RuntimeException("Klarte ikke å hente organisasjoner code=${response.code}")
 			}
 
-			val body = response.body?.string() ?: throw RuntimeException("Body is missing")
-
-			return fromJsonString<List<AuthorizedParty>>(body)
+			return fromJsonString<List<AuthorizedParty>>(response.body.string())
 		}
 	}
 

--- a/src/main/kotlin/no/nav/amt_altinn_acl/jobs/leaderelection/LeaderElection.kt
+++ b/src/main/kotlin/no/nav/amt_altinn_acl/jobs/leaderelection/LeaderElection.kt
@@ -42,15 +42,9 @@ class LeaderElection(
 				throw RuntimeException(message)
 			}
 
-			response.body?.string()?.let {
-				val leader: Leader = fromJsonString<Leader>(it)
-				return leader.name == hostname
-			}
+			val leader: Leader = fromJsonString(response.body.string())
+			return leader.name == hostname
 		}
-
-		val message = "Kall mot elector returnerer ikke data"
-		log.error(message)
-		throw RuntimeException(message)
 	}
 
 	private fun getHttpPath(url: String): String =

--- a/src/main/kotlin/no/nav/amt_altinn_acl/utils/JsonUtils.kt
+++ b/src/main/kotlin/no/nav/amt_altinn_acl/utils/JsonUtils.kt
@@ -13,7 +13,5 @@ object JsonUtils {
 		.registerModule(JavaTimeModule())
 		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
-	inline fun <reified T> fromJsonString(jsonStr: String): T {
-		return objectMapper.readValue(jsonStr)
-	}
+	inline fun <reified T : Any> fromJsonString(jsonStr: String): T = objectMapper.readValue(jsonStr)
 }


### PR DESCRIPTION
I okhttp:5  ble `Response#body` endret fra `ResponseBody?` til `ResponseBody`.

Dette innebærer at 
```
val body = response.body?.string() ?: throw RuntimeException("Body is missing")
return fromJsonString<List<AuthorizedParty>>(body)
```
kan nå skrives som
```
return fromJsonString<List<AuthorizedParty>>(response.body.string())
```