### PR TITLE
Bump dependencies - 20250728094333

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     val kotlinVersion = "2.2.0"
 
-    id("org.springframework.boot") version "3.5.3"
+    id("org.springframework.boot") version "3.5.4"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.spring") version kotlinVersion


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250728094333 branch:

## Successfully Rebased PRs
- [Bump org.springframework.boot from 3.5.3 to 3.5.4](https://github.com/navikt/amt-altinn-acl/pull/310)
- [Bump no.nav.security:token-validation-spring from 5.0.30 to 5.0.33](https://github.com/navikt/amt-altinn-acl/pull/309)


